### PR TITLE
Update plot.m

### DIFF
--- a/core/@drumplot/plot.m
+++ b/core/@drumplot/plot.m
@@ -97,10 +97,8 @@ drawnow
         end
         w = [temp_cobj.waveforms{1,:}];
     end
-w(1)
-w(2)
      
-     if ~isempty(w)
+    if ~isempty(w)
         % go through w and check the channeltag is same as drumplotobj.wave
         mainctag = get(drumplotobj.wave,'ChannelTag');
         w2=[];


### PR DESCRIPTION
Remove unnecessary calls to w(1) and w(2) which cause code to break if no catalog, arrival, or detection objects are provided. 
Fix indentation.